### PR TITLE
Remove duplicate

### DIFF
--- a/_data/conferences/WrocLoverb2016.json
+++ b/_data/conferences/WrocLoverb2016.json
@@ -1,1 +1,0 @@
-{"name":"WrocLove.rb","conferenceStart":"2016-03-11","conferenceEnd":"2016-03-11","callForPapersEnd":"2016-01-11","url":"http://cfp.wrocloverb.com/authentications","lang":"en","location":"Wrocław, Poland","tags":"Ruby"}


### PR DESCRIPTION
- duplicate of  https://github.com/callForPapers/callForPapers.github.io/blob/master/_data/conferences/wroc_loverb.json
- wrong conference end date
- invalid CFP url 
- only ruby tag
